### PR TITLE
style: comply with `partialeq_to_none`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -80,7 +80,7 @@ impl Request {
 
     fn parse(&mut self, env: Option<Env>, extra_args: HashMap<String, serde_json::Value>) -> Result<()> {
         // Make sure we have the file content loaded.
-        if self.fstr == None {
+        if self.fstr.is_none() {
             self.load()?;
         }
 


### PR DESCRIPTION
This PR resolves the [`partialeq_to_none`](https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none) warning.