### PR TITLE
style: comply with `needless_borrows_for_generic_args`

### DIFF
--- a/src/reqq.rs
+++ b/src/reqq.rs
@@ -112,7 +112,7 @@ fn get_all_fpaths(dir: &str) -> Vec<String> {
                 }
 
                 let path_display = e.path().display().to_string();
-                match path_display.as_str().trim_start_matches(&dir) {
+                match path_display.as_str().trim_start_matches(dir) {
                     "" => None,
                     _ => Some(path_display),
                 }


### PR DESCRIPTION
This PR resolves the [`needless_borrows_for_generic_args`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args) warning.

https://github.com/sethetter/reqq/blob/6f63c1cddd35ba5b44104cd8c92500105027ba56/src/reqq.rs#L104
Now slightly less.

Similar to #18.