### PR TITLE
Implemented an edit command to open the request in $EDITOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ engine, so anything that's fair game there is fair game in `.reqq` files.
 - `reqq [--env=<env>] <request>`, executes a request.
 - `reqq list`, lists all available requests.
 - `reqq envs`, lists available envs.
+- `reqq edit <request>`, opens a request file in $EDITOR.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,12 @@ enum Commands {
 
     /// Lists available environments.
     Envs,
+
+    /// Opens a request file in $EDITOR.
+    Edit {
+        /// The name of the request to edit.
+        request_name: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -81,6 +87,9 @@ fn main() -> Result<()> {
             for env_name in reqq.list_envs().into_iter() {
                 println!("{}", env_name);
             }
+        }
+        Some(Commands::Edit { request_name }) => {
+            reqq.edit(request_name)?;
         }
         None => {
             let request_name = args.request_name.as_deref().expect("No request name provided.");

--- a/src/reqq.rs
+++ b/src/reqq.rs
@@ -85,6 +85,20 @@ impl<'a> Reqq<'a> {
         Ok(result)
     }
 
+    /// Opens a request file in $EDITOR.
+    pub fn edit(&self, req_name: &str) -> Result<()> {
+        let req = self.get_req(req_name)?;
+        let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+        let status = std::process::Command::new(editor)
+            .arg(req.file_path())
+            .status()?;
+        
+        if !status.success() {
+            return Err(anyhow!("Editor exited with non-zero status"));
+        }
+        Ok(())
+    }
+
     fn get_req(&self, name: &str) -> Result<Request> {
         self.reqs
             .clone()

--- a/src/request.rs
+++ b/src/request.rs
@@ -44,6 +44,11 @@ impl Request {
             .to_owned()
     }
 
+    /// Returns the file path of the request.
+    pub fn file_path(&self) -> &str {
+        &self.fpath
+    }
+
     fn load(&mut self) -> Result<()> {
         if self.fstr.is_none() {
             let fstr = fs::read_to_string(self.fpath.clone())?;


### PR DESCRIPTION
I successfully implemented the edit command for the reqq CLI tool that opens a request file in the user's $EDITOR. 
Resolves #16 

The implementation includes:

### Changes Made:
1. Added Edit subcommand in src/main.rs:
    - Added Edit { request_name: String } to the Commands enum
    - Added command handling that calls reqq.edit(request_name)
2. Implemented edit method in src/reqq.rs:
    - Added edit() method that finds the request and opens it in $EDITOR
    - Uses vi as fallback if $EDITOR is not set
    - Returns proper error handling if editor fails
3. Added file_path method in src/request.rs:
    - Added file_path() method to expose the request file path
4. Updated documentation in README.md:
    - Added the new edit command to the Commands section

### Usage:
`reqq edit <request_name>`

### The command will:
- Find the request file by name in the .reqq directory
- Open it using the editor specified in $EDITOR environment variable
- Fall back to vi if $EDITOR is not set
- Handle errors gracefully if the request doesn't exist or editor fails

https://github.com/user-attachments/assets/12b89cd1-568c-42a1-8a90-1637173026fc

The implementation is minimal, focused, and follows the existing code patterns in the project.