### PR TITLE
Fix help documentation to clarify request_name requirement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Parser)]
 #[command(name = "reqq", version = "0.3.0", author = "Seth Etter <sethetter@gmail.com>", about = "Like insomnia or postman, but a CLI.", long_about = None)]
 struct Args {
-    /// The name of the request to execute.
+    /// The name of the request to execute (required when no subcommand is specified).
     request_name: Option<String>,
 
     /// The environment file to load.


### PR DESCRIPTION
## Changes
- Updated the help text for request_name argument to clarify it's required when no subcommand is specified
- Changed from "The name of the request to execute." to "The name of the request to execute (required when no subcommand is specified)."

### Testing
Run reqq --help to verify the updated help text clearly indicates when request_name is required.

### Before:
`The name of the request to execute.`

### After:
`The name of the request to execute (required when no subcommand is specified).`

FIXES #15 